### PR TITLE
Issue #6: Changing default aperture in lsst_comet_activity.py

### DIFF
--- a/src/sorcha_community_utils/activity/lsst_comet/lsst_comet_activity.py
+++ b/src/sorcha_community_utils/activity/lsst_comet/lsst_comet_activity.py
@@ -72,7 +72,7 @@ class LSSTCometActivity(AbstractCometaryActivity):
         # this calculates the coma magnitude in each filter
         try:
             for filt in observing_filters:
-                df.loc[df["optFilter"] == filt, "coma_magnitude"] = com.mag(g, filt, rap=df["seeingFwhmEff"])
+                df.loc[df["optFilter"] == filt, "coma_magnitude"] = com.mag(g, filt, rap=1.)
         except KeyError as err:
             self._log_exception(err)
 

--- a/src/sorcha_community_utils/activity/lsst_comet/lsst_comet_activity.py
+++ b/src/sorcha_community_utils/activity/lsst_comet/lsst_comet_activity.py
@@ -72,7 +72,7 @@ class LSSTCometActivity(AbstractCometaryActivity):
         # this calculates the coma magnitude in each filter
         try:
             for filt in observing_filters:
-                df.loc[df["optFilter"] == filt, "coma_magnitude"] = com.mag(g, filt, rap=1.)
+                df.loc[df["optFilter"] == filt, "coma_magnitude"] = com.mag(g, filt, rap=1.0)
         except KeyError as err:
             self._log_exception(err)
 

--- a/src/sorcha_community_utils/activity/lsst_comet/lsst_comet_activity.py
+++ b/src/sorcha_community_utils/activity/lsst_comet/lsst_comet_activity.py
@@ -72,6 +72,8 @@ class LSSTCometActivity(AbstractCometaryActivity):
         # this calculates the coma magnitude in each filter
         try:
             for filt in observing_filters:
+                # here rap is the aperture width, hardcoded here to 1.0 arcsec
+                # the code assumes an infinite coma so is thus only accurate for small apertures
                 df.loc[df["optFilter"] == filt, "coma_magnitude"] = com.mag(g, filt, rap=1.0)
         except KeyError as err:
             self._log_exception(err)

--- a/tests/activity/lsst_comet/test_PPCalculateApparentMagnitude.py
+++ b/tests/activity/lsst_comet/test_PPCalculateApparentMagnitude.py
@@ -46,9 +46,6 @@ def test_PPCalculateSimpleCometaryMagnitude():
     # Updates the dictionary of available subclasses of `AbstractCometaryActivity`
     update_activity_subclasses()
 
-    # data is for 67P, taken by Colin Snodgrass, and validated against same
-    # abnormally large seeing is to account for Colin's use of an aperture measured at comet distance
-
     cometary_obs = pd.DataFrame(
         {
             "optFilter": ["r", "r"],
@@ -56,7 +53,6 @@ def test_PPCalculateSimpleCometaryMagnitude():
             "H_r": [15.35, 15.35],
             "afrho1": [1552, 1552],
             "k": [-3.35, -3.35],
-            "seeingFwhmEff": [8.064748, 3.206723],
         }
     )
 
@@ -66,4 +62,4 @@ def test_PPCalculateSimpleCometaryMagnitude():
 
     df_comet = PPCalculateSimpleCometaryMagnitude(cometary_obs, ["r"], rho, delta, alpha, "lsst_comet")
 
-    assert_almost_equal(df_comet["TrailedSourceMag"], [13.516, 22.010], decimal=3)
+    assert_almost_equal(df_comet["TrailedSourceMag"], [15.757, 22.461], decimal=3)


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
Closes #6. The default aperture used by lsst_comet_activity.py was set to the seeing. As per conversation with Colin Snodgrass outlined in the issue, using the seeing will cause comets to seem brighter at poorer seeing, which is obviously not the case.
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
I have simply changed the aperture to 1 arcsec. The user may feel free to change it to something larger at their own risk (lsstcomet assumes infinite coma, so large apertures will produce spurious results).

I have also updated the test.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover any changes
- [x] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
