### PR TITLE
Explicitly include both modules in the top level __init__ file.

### DIFF
--- a/src/sorcha_community_utils/__init__.py
+++ b/src/sorcha_community_utils/__init__.py
@@ -1,3 +1,6 @@
+from sorcha_community_utils import activity
+from sorcha_community_utils import lightcurve
+
 __all__ = [
     "activity",
     "lightcurve",


### PR DESCRIPTION
I wasn't being clear enough in the previous PR for jupyter notebooks. This PR makes the import of the submodule more explicit and allows Python kernels for jupyter notebooks to find the required packages. 