### PR TITLE
Updates to remove python 3.9

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,63 +1,12 @@
-<!-- 
-Thank you for your contribution to the repo :)
+Fixes # .
 
-Pull Request (PR) Instructions:
-Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.
+Describe your changes.
 
-Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
- 
-How to link to a PR:
-https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
--->
+## Review Checklist for Source Code Changes
 
-## Change Description
-<!--- 
-Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".
+- [ ] Does pip install still work?
+- [ ] Have you written a unit test for any new functions?
+- [ ] Do all the units tests run successfully?
+- [ ] Does Sorcha/Sorcha addons run successfully on a test set of input files/databases?
+- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
 
-If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
--->
-- [ ] My PR includes a link to the issue that I am addressing
-
-
-
-## Solution Description
-<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
-
-
-
-## Code Quality
-- [ ] I have read the Contribution Guide
-- [ ] My code follows the code style of this project
-- [ ] My code builds (or compiles) cleanly without any errors or warnings
-- [ ] My code contains relevant comments and necessary documentation
-
-## Project-Specific Pull Request Checklists
-<!--- Please only use the checklist that apply to your change type(s) -->
-
-### Bug Fix Checklist
-- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
-- [ ] My change includes a breaking change
-  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
-
-### New Feature Checklist
-- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
-- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
-- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
-- [ ] My change includes a breaking change
-  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
-
-### Documentation Change Checklist
-- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
-
-### Build/CI Change Checklist
-- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
-- [ ] If this is a new CI setup, I have added the associated badge to the README
-
-<!-- ### Version Change Checklist [For Future Use] -->
-
-### Other Change Checklist
-- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
-- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
-- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
-- [ ] My change includes a breaking change
-  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Partially addresses #24 by removing 3.9 which is not recommended with numpy 2.0 - Also fixed the lengthly PR template. 