### PR TITLE
numpy 2.0 patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "pandas",
-    "numpy",
+    "numpy<2.0",
     "sorcha",
     "astropy",
     "scipy",


### PR DESCRIPTION
Update pyproject.toml to pin numpy because of pytable issues in sorcha

Partly addresses #25 

